### PR TITLE
Description content appears unformatted in the Doc Lib view

### DIFF
--- a/alfresco-mm-repo/pom.xml
+++ b/alfresco-mm-repo/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.alfresco.mediamanagement</groupId>
         <artifactId>alfresco-mm-parent</artifactId>
-        <version>1.4-IXXUS-SNAPSHOT</version>
+        <version>1.5-IXXUS-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/alfresco-mm-share/pom.xml
+++ b/alfresco-mm-share/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.alfresco.mediamanagement</groupId>
         <artifactId>alfresco-mm-parent</artifactId>
-        <version>1.4-IXXUS-SNAPSHOT</version>
+        <version>1.5-IXXUS-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     

--- a/alfresco-mm-share/src/main/resources/META-INF/components/documentlibrary/oup-document-list-renderers.js
+++ b/alfresco-mm-share/src/main/resources/META-INF/components/documentlibrary/oup-document-list-renderers.js
@@ -1,0 +1,26 @@
+(function() {
+
+	/*
+	 * https://ixxusdev.atlassian.net/browse/IXSUPP-79
+	 * Expected result: Description content appears unformatted in the Doc Lib view.
+	 */
+	if (Alfresco.DocumentList){    
+		YAHOO.Bubbling.fire("registerRenderer", {
+			
+			propertyName : "plainDescription",
+			renderer : function registerRendererDescription(record, label) {
+				var description = record.jsNode.properties.description;
+				var plainDescription = '';
+				// Description non-blank?
+	            if (description && description !== ""){
+	            	var elem = document.createElement('div');
+	                elem.innerHTML = description;
+	                plainDescription = (elem.textContent===undefined) ? elem.innerText : elem.textContent;	                
+				}
+				
+				return plainDescription;
+			}
+		});
+	}
+
+})();

--- a/alfresco-mm-share/src/main/resources/META-INF/share-config-custom.xml
+++ b/alfresco-mm-share/src/main/resources/META-INF/share-config-custom.xml
@@ -1,7 +1,7 @@
 <alfresco-config>
 
     <!-- Document Library config section -->
-    <config evaluator="string-compare" condition="DocumentLibrary">
+    <config evaluator="string-compare" condition="DocumentLibrary" replace="true">
 
         <!-- Used by the "Manage Aspects" action For custom aspects, remember to
             also add the relevant i18n string(s) cm_myaspect=My Aspect -->
@@ -30,7 +30,7 @@
                 <banner index="30" id="syncFailed"
                     evaluator="evaluator.doclib.metadata.hasSyncFailedBanner">{syncFailed}</banner>
                 <line index="10" id="date">{date}{size}</line>
-                <line index="20" id="description" view="detailed">{description}</line>
+                <line index="20" id="plainDescription" view="detailed">{plainDescription}</line>
                 <line index="30" id="tags" view="detailed">{tags}</line>
                 <line index="40" id="categories" view="detailed"
                     evaluator="evaluator.doclib.metadata.hasCategories">{categories}</line>
@@ -45,9 +45,14 @@
                 <line index="80" id="tags-spreadsheet" view="spreadsheet">{tags}</line>
             </template>
         </metadata-templates>
-
     </config>
 
+    <config evaluator="string-compare" condition="DocLibCustom">
+        <dependencies>
+            <js src="/components/documentlibrary/oup-document-list-renderers.js" />            
+        </dependencies>
+    </config>
+    
     <config evaluator="aspect" condition="iptcxmp:iptcxmpAspect">
         <forms>
             <form>

--- a/alfresco-mm-share/src/main/resources/META-INF/share-config-custom.xml
+++ b/alfresco-mm-share/src/main/resources/META-INF/share-config-custom.xml
@@ -30,6 +30,7 @@
                 <banner index="30" id="syncFailed"
                     evaluator="evaluator.doclib.metadata.hasSyncFailedBanner">{syncFailed}</banner>
                 <line index="10" id="date">{date}{size}</line>
+<!-- IXSUPP-79  <line index="20" id="description" view="detailed">{description}</line> -->
                 <line index="20" id="plainDescription" view="detailed">{plainDescription}</line>
                 <line index="30" id="tags" view="detailed">{tags}</line>
                 <line index="40" id="categories" view="detailed"

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.alfresco.mediamanagement</groupId>
         <artifactId>alfresco-mm-parent</artifactId>
-        <version>1.4-IXXUS-SNAPSHOT</version>
+        <version>1.5-IXXUS-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.alfresco.mediamanagement</groupId>
     <artifactId>alfresco-mm-parent</artifactId>
-    <version>1.4-IXXUS-SNAPSHOT</version>
+    <version>1.5-IXXUS-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Alfresco Media Management Parent Project</name>
 


### PR DESCRIPTION
Replace the field 'description' with 'plainDescription' for show plain text in the document library view.